### PR TITLE
Fix: CreatePersonalAccessToken ignores the field hashAlgorithm

### DIFF
--- a/src/Server/src/Core/Data/PersonalAccessToken/PersonalAccessTokenService.cs
+++ b/src/Server/src/Core/Data/PersonalAccessToken/PersonalAccessTokenService.cs
@@ -114,7 +114,8 @@ namespace IdOps
                 .SetSource(request.Source)
                 .SetTenant(request.Tenant)
                 .SetAllowedApplications(request.AllowedApplicationIds)
-                .SetAllowedScopes(request.AllowedScopes);
+                .SetAllowedScopes(request.AllowedScopes)
+                .SetHashAlgorithm(request.HashAlgorithm);
 
             foreach (var (type, value) in request.ClaimsExtensions)
             {


### PR DESCRIPTION
The mutation CreatePersonalAccessToken has an input field hashAlgorithm which was ignored until now. 
This pr fixes this. 
