### PR TITLE
Fix crash on startup 

### DIFF
--- a/src/Server/src/Api.Host/appsettings.json
+++ b/src/Server/src/Api.Host/appsettings.json
@@ -33,8 +33,8 @@
     "Azure": {
       "SecretEncryption": {
         "AzureKeyVault": {
-          "KeyVaultUri": "https://xxx.vault.azure.net/",
-          "EncryptionKeyName": "xxx"
+          "KeyVaultUri": "",
+          "EncryptionKeyName": ""
         }
       }
     }

--- a/src/Server/src/Core/Configuration/IdOpsServerBuilderExtensions.cs
+++ b/src/Server/src/Core/Configuration/IdOpsServerBuilderExtensions.cs
@@ -99,8 +99,8 @@ namespace IdOps
             IConfiguration configuration)
         {
             services.AddAzureKeyVault(configuration);
-            services.AddEncryptionProvider<KeyVaultEncryptionProvider>(isDefault: true);
-            services.AddEncryptionProvider<NoEncryptionProvider>(isDefault: false);
+            services.AddEncryptionProvider<KeyVaultEncryptionProvider>(isDefault: false);
+            services.AddEncryptionProvider<NoEncryptionProvider>(isDefault: true);
         }
 
         private static void AddConsumers(this IBusRegistrationConfigurator busConfigurator)

--- a/src/Server/src/Core/Encryption/KeyvaultEncryption/AzureKeyVaultExtension.cs
+++ b/src/Server/src/Core/Encryption/KeyvaultEncryption/AzureKeyVaultExtension.cs
@@ -15,6 +15,13 @@ public static class AzureKeyVaultExtension
             .GetSection("IdOps:Azure:SecretEncryption:AzureKeyVault")
             .Get<AzureKeyVaultOptions>();
 
+        //injects null if no KeyVault options configured but KeyVault is registered on startup
+        if (string.IsNullOrEmpty(options.KeyVaultUri) || string.IsNullOrEmpty(options.EncryptionKeyName))
+        {
+            services.TryAddSingleton<CryptographyClient>(provider => null);
+            return services;
+        }
+        
         services.AddSingleton(options);
         services.AddSingleton<ICryptographyClientProvider, AzureKeyVaultCryptographyClientProvider>();
         services.TryAddSingleton<CryptographyClient>(provider =>


### PR DESCRIPTION
If Azure KeyVault was configured on startup but no configuration was supplied in appsettings.json, IdOps would not start.
- starts now
- shows "an api error has occured" if one tries to save secret encrypted
